### PR TITLE
FIX (types): fix item type for IItemRenderer

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -11,7 +11,7 @@ export interface IState {
 export interface IMethods {
   removeItem: () => void;
   dropDown: () => void;
-  addItem: () => void;
+  addItem: (item: IItemRenderer['item']) => void;
   setSearch: () => void;
   getInputSize: () => void;
   toggleSelectAll: () => void;
@@ -43,8 +43,8 @@ export interface IKeyDown {
 	setState?: () => void;
 }
 
-export interface IItemRenderer {
-  item?: number;
+export interface IItemRenderer<T> {
+  item?: T;
   itemIndex?: number;
   props?: ISelectProps;
   state?: IState;


### PR DESCRIPTION
Fix IItemRenderer interface to make item type generic and update addItem interface to include item as a parameter.

Fixes TS error where `addItem(item)` expects 0 arguments. This is not correct as `addItem` expects the item as a parameter.