### PR TITLE
FIX (props): fix prop type warnings

### DIFF
--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -724,6 +724,7 @@ exports[`<Select/> component <Select/> renders with name 1`] = `
       />
     </div>
     <input
+      defaultValue={Array []}
       disabled={false}
       name="form-select"
       pattern={false}
@@ -736,7 +737,6 @@ exports[`<Select/> component <Select/> renders with name 1`] = `
         }
       }
       tabIndex={-1}
-      value={Array []}
     />
     <div
       className="react-dropdown-select-dropdown-handle emotion-4 emotion-5"

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -727,7 +727,6 @@ exports[`<Select/> component <Select/> renders with name 1`] = `
       defaultValue={Array []}
       disabled={false}
       name="form-select"
-      pattern={false}
       required={false}
       style={
         Object {

--- a/src/index.js
+++ b/src/index.js
@@ -539,7 +539,7 @@ Select.defaultProps = {
   direction: 'ltr',
   name: null,
   required: false,
-  pattern: false,
+  pattern: undefined,
   onChange: () => undefined,
   onDropdownOpen: () => undefined,
   onDropdownClose: () => undefined,

--- a/src/index.js
+++ b/src/index.js
@@ -473,7 +473,7 @@ export class Select extends Component {
               name={this.props.name}
               required={this.props.required}
               pattern={this.props.pattern}
-              value={this.state.values.map(value => value[this.props.labelField]).toString() || []}
+              defaultValue={this.state.values.map(value => value[this.props.labelField]).toString() || []}
               disabled={this.props.disabled}
             />
           )}


### PR DESCRIPTION
- use `defaultValue` instead of `value` in hidden input, so that React won't complain about missing `onChange` handler
- fix initial value for `pattern` prop

resolves #74