### PR TITLE
FIX (clearOnSelect)[#191] Single Select: Dropdown should show all results (clear search) upon selection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -270,7 +270,10 @@ export class Select extends Component {
       });
     }
 
-    this.props.clearOnSelect && this.setState({ search: '' });
+    this.props.clearOnSelect &&
+      this.setState({ search: '' }, () => {
+        this.setState({ searchResults: this.searchResults() });
+      });
 
     return true;
   };


### PR DESCRIPTION
Resolves #191 

The search query was already successfully being set to ``""``, but the searchResults state was not being changed according to the new empty search query value. Added callback function to the setState for the search query that fetches the new state value for searchResults (all options).

Thanks for this component!