### PR TITLE
FEATURE (Single Select): Selected item should be visible when dropdown is opened

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -7,6 +7,13 @@ import { LIB_NAME } from '../constants';
 class Item extends Component {
   item = React.createRef();
 
+  componentDidMount() {
+    const { props, methods } = this.props;
+
+    if (!props.multi && props.keepSelectedInList && methods.isSelected(this.props.item))
+      this.item.current.scrollIntoView({ block: 'nearest', inline: 'start' });
+  }
+
   componentDidUpdate() {
     if (this.props.state.cursor === this.props.itemIndex) {
       this.item.current &&


### PR DESCRIPTION
Implements feature described in #180

Selected item is now scrolled into view when dropdown is opened in single select. Would love to hear thoughts on whether this feature should be toggled via user-provided props.

Thanks! Happy weekend.