### PR TITLE
Add null check before attempting to scroll item into view in single-select dropdown

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -10,7 +10,12 @@ class Item extends Component {
   componentDidMount() {
     const { props, methods } = this.props;
 
-    if (!props.multi && props.keepSelectedInList && methods.isSelected(this.props.item))
+    if (
+      this.item.current &&
+      !props.multi &&
+      props.keepSelectedInList &&
+      methods.isSelected(this.props.item)
+    )
       this.item.current.scrollIntoView({ block: 'nearest', inline: 'start' });
   }
 


### PR DESCRIPTION
Fixes #208 and perhaps #211. 

Added null check before trying to scroll item into view, because ref is null when a custom itemRenderer is used.