### PR TITLE
Update dropdown list item focus handling for screen reader accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@podverse/react-dropdown-select",
-  "version": "4.8.4-beta.1",
+  "version": "4.8.4-beta.2",
   "description": "Customizable dropdown select for react",
   "main": "dist/react-dropdown-select.js",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-dropdown-select",
-  "version": "4.8.4",
+  "name": "@podverse/react-dropdown-select",
+  "version": "4.8.4-beta.1",
   "description": "Customizable dropdown select for react",
   "main": "dist/react-dropdown-select.js",
   "module": "lib/index.js",

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -23,6 +23,7 @@ class Item extends Component {
     if (this.props.state.cursor === this.props.itemIndex) {
       this.item.current &&
         this.item.current.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
+      this.item.current.focus();
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,8 @@ export class Select extends Component {
     pattern: PropTypes.string,
     name: PropTypes.string,
     backspaceDelete: PropTypes.bool,
-    compareValuesFunc: PropTypes.func
+    compareValuesFunc: PropTypes.func,
+    dropdownAriaDescription: PropTypes.string
   };
 
   constructor(props) {
@@ -502,6 +503,7 @@ export class Select extends Component {
       <ClickOutside onClickOutside={(event) => this.dropDown('close', event)}>
         <ReactDropdownSelect
           onKeyDown={this.handleKeyDown}
+          aria-description={this.props.dropdownAriaDescription}
           aria-label="Dropdown select"
           aria-expanded={this.state.dropdown}
           onClick={(event) => this.dropDown('open', event)}
@@ -602,7 +604,8 @@ Select.defaultProps = {
   handleKeyDownFn: () => undefined,
   additionalProps: null,
   backspaceDelete: true,
-  compareValuesFunc: isEqual
+  compareValuesFunc: isEqual,
+  dropdownAriaDescription: 'Use the up and down arrows to focus on dropdown items.'
 };
 
 const ReactDropdownSelect = styled.div`

--- a/src/index.js
+++ b/src/index.js
@@ -413,7 +413,7 @@ export class Select extends Component {
     const tab = event.key === 'Tab' && !event.shiftKey;
     const shiftTab = event.shiftKey && event.key === 'Tab';
 
-    if (arrowDown && !state.dropdown) {
+    if ((arrowDown || enter) && !state.dropdown) {
       event.preventDefault();
       this.dropDown('open');
       return setState({
@@ -605,7 +605,7 @@ Select.defaultProps = {
   additionalProps: null,
   backspaceDelete: true,
   compareValuesFunc: isEqual,
-  dropdownAriaDescription: 'Use the up and down arrows to focus on dropdown items.'
+  dropdownAriaDescription: 'Press the enter key or down arrow to show the dropdown menu. Then use the tab key, or up and down arrows to focus on the dropdown items.'
 };
 
 const ReactDropdownSelect = styled.div`

--- a/types.d.ts
+++ b/types.d.ts
@@ -153,6 +153,7 @@ declare module 'react-dropdown-select' {
     separatorRenderer?: ({ props, state, methods }: SelectRenderer<T>) => JSX.Element;
     additionalProps?: React.HTMLAttributes<HTMLDivElement>;
     wrapperClassName?: string;
+    dropdownAriaLabel?: string;
   }
 
   export interface DropDownProps {


### PR DESCRIPTION
This pull request isn't ready for merge. I don't think this is a proper solution so maybe these changes shouldn't be accepted. At the moment though these changes seem to have improved screen reader accessibility for Mac VoiceOver. Any feedback would be appreciated.