### PR TITLE
Remove unnecessary onChange call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,9 +124,6 @@ export class Select extends Component {
       this.setState(
         {
           values: this.props.values
-        },
-        () => {
-          this.props.onChange(this.state.values);
         }
       );
       this.updateSelectBounds();


### PR DESCRIPTION
As far as I can tell, this `onChange` call is extraneous. `onChange` will be called again in the next update cycle when `prevState.values` and `this.state.values` are not equal ([src/index.js#L139-L142](https://github.com/sanusart/react-dropdown-select/blob/master/src/index.js#L139-L142)).