### PR TITLE
Add faker as a dev dependency, fix usage to current API

### DIFF
--- a/docs/src/options.js
+++ b/docs/src/options.js
@@ -1,41 +1,41 @@
-import faker from '@faker-js/faker';
+import { faker } from '@faker-js/faker';
 
 export const options = [
   ...Array.from(Array(30).keys()).map((data) => ({
-    id: faker.random.uuid(),
-    name: `${faker.name.firstName()} ${faker.name.lastName()}`,
-    username: faker.internet.userName(),
+    id: faker.string.uuid(),
+    name: `${faker.person.firstName()} ${faker.person.lastName()}`,
+    username: faker.internet.username(),
     email: faker.internet.email(),
     address: {
-      street: faker.address.streetName(),
-      suite: faker.random.number(),
-      city: faker.address.city(),
-      zipcode: faker.address.zipCode(),
+      street: faker.location.street(),
+      suite: faker.location.secondaryAddress(),
+      city: faker.location.city(),
+      zipcode: faker.location.zipCode(),
       geo: {
-        lat: faker.address.latitude(),
-        lng: faker.address.longitude()
+        lat: faker.location.latitude(),
+        lng: faker.location.longitude()
       }
     },
-    phone: faker.phone.phoneNumber(),
+    phone: faker.phone.number(),
     website: faker.internet.domainName(),
     company: {
-      name: faker.company.companyName(),
+      name: faker.company.name(),
       catchPhrase: faker.company.catchPhrase(),
-      bs: faker.company.bs()
+      bs: faker.company.buzzPhrase()
     }
   }))
 ];
 
 export const optionsBase = (count = 30) => [
   ...Array.from(Array(count).keys()).map((data) => ({
-    value: faker.random.uuid(),
-    label: `${faker.name.firstName()} ${faker.name.lastName()}`
+    value: faker.string.uuid(),
+    label: `${faker.person.firstName()} ${faker.person.lastName()}`
   }))
 ];
 
 export const optionsSimple = (count = 30) => [
   ...Array.from(Array(count).keys()).map((data) => ({
-    id: faker.random.uuid(),
-    name: `${faker.name.firstName()} ${faker.name.lastName()}`
+    id: faker.string.uuid(),
+    name: `${faker.person.firstName()} ${faker.person.lastName()}`
   }))
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@babel/preset-react": "^7.7.4",
         "@emotion/babel-plugin": "11.11.0",
         "@emotion/jest": "11.11.0",
+        "@faker-js/faker": "^10.1.0",
         "@storybook/addon-docs": "7.1.1",
         "@storybook/addon-essentials": "7.1.1",
         "@storybook/addon-interactions": "7.1.1",
@@ -2995,6 +2996,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.1.0.tgz",
+      "integrity": "sha512-C3mrr3b5dRVlKPJdfrAXS8+dq+rq8Qm5SNRazca0JKgw1HQERFmrVb0towvMmw5uu8hHKNiQasMaR/tydf3Zsg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@fal-works/esbuild-plugin-global-externals": {
@@ -8446,20 +8464,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@storybook/preset-react-webpack/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@storybook/preset-react-webpack/node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -13906,20 +13910,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/eventsource": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.1.tgz",
-      "integrity": "sha512-qV5ZC0h7jYIAOhArFJgSfdyz6rALJyb270714o7ZtNnw2WSJ+eexhKtE0O8LYPRsHZHf2osHKZBxGPvm3kPkCA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "original": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/exec-sh": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.6.tgz",
@@ -17656,23 +17646,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -17722,24 +17695,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/jest-circus/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.3.0.tgz",
@@ -17761,24 +17716,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-circus/node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-circus/node_modules/jest-util": {
@@ -17811,37 +17748,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-circus/node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-circus/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/jest-circus/node_modules/slash": {
@@ -23406,17 +23312,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "url-parse": "^1.4.3"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -25690,54 +25585,6 @@
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
       }
-    },
-    "node_modules/sockjs-client": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.0.tgz",
-      "integrity": "sha512-qVHJlyfdHFht3eBFZdKEXKTlb7I4IV41xnVNo8yUKA1UHcPJwgW2SvTq9LhnjjCywSkSK7c/e4nghU0GOoMCRQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^3.2.7",
-        "eventsource": "^1.1.0",
-        "faye-websocket": "^0.11.4",
-        "inherits": "^2.0.4",
-        "url-parse": "^1.5.10"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
-      }
-    },
-    "node_modules/sockjs-client/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/sockjs-client/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/sockjs-client/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/sockjs/node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@babel/preset-react": "^7.7.4",
     "@emotion/babel-plugin": "11.11.0",
     "@emotion/jest": "11.11.0",
+    "@faker-js/faker": "^10.1.0",
     "@storybook/addon-docs": "7.1.1",
     "@storybook/addon-essentials": "7.1.1",
     "@storybook/addon-interactions": "7.1.1",


### PR DESCRIPTION
## Why is this needed?

When I pulled down the repository and tried running the demo via storybook, I encountered a number of errors: first not finding faker at all and then many of the functions not existing.

## What changed?

- add @faker-js/faker as a dev dependency
- fix the import statement
- fix the calling of several faker functions for the current 10.x version of that library